### PR TITLE
feat: add optional root domain config

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ class ParsonyServer {
         "api_key": "b58445978454a0d72a4dfabad96f5f8542ebf927.key",
         "secret":"c3af42468f78d431729ab501ee1df6d2d6e8e03d.secret",
         "services_uri": "http://localhost:8070/json-api",
+        "root_domain": "example.com", // valid domain for HTTP cookies, optional
         "endpoints":{
           "api":"/json-api",
           "sms":"/sms"
@@ -55,8 +56,9 @@ class ParsonyServer {
       services_uri,
       api_key,
       secret,
+      root_domain,
     } = this.configs;
-    const apiRouter = new ApiRouter(app, services_uri);
+    const apiRouter = new ApiRouter(app, services_uri, root_domain);
     apiRouter.setApiCredentials(api_key, secret);
     apiRouter.setEndpoints({ api, sms });
     apiRouter.attachEndpoints();

--- a/libs/apiRouter.js
+++ b/libs/apiRouter.js
@@ -33,11 +33,12 @@ class ApiRouter {
    * Instantiate
    * @param {object} app - Express app
    * @param {string} servicesEndpoint - private parsony services api endpoint
+   * @param {string} rootDomain - Root domain of the app
    */
-  constructor(app, servicesEndpoint) {
+  constructor(app, servicesEndpoint, rootDomain = null) {
     this.servicesEndpoint = servicesEndpoint;
     this.app = app;
-    this.sessionManager = new SessionManager(app);
+    this.sessionManager = new SessionManager(app, rootDomain);
     this.app.use(this.sessionManager.observe());
     this.apiEndpoint = "/json-api";
     this.smsEndpoint = "/sms";

--- a/libs/sessionManager.js
+++ b/libs/sessionManager.js
@@ -18,10 +18,12 @@ const cookieParser = require("cookie-parser");
 class SessionManager {
   /**
    * @param {object} app - Express app
+   * @param {string} rootDomain - Root domain of the app
    */
-  constructor(app) {
+  constructor(app, rootDomain = null) {
     this.app = app;
     this.app.use(cookieParser());
+    this.rootDomain = rootDomain;
   }
 
   /**
@@ -82,7 +84,11 @@ class SessionManager {
   }
 
   static _makeSessionCookie(token) {
-    return `parsonySession=${token}; HttpOnly`;
+    let cookie = `parsonySession=${token}; HttpOnly`;
+    if (this.rootDomain) {
+      cookie = `${cookie}; Domain=${this.rootDomain}`;
+    }
+    return cookie;
   }
 
   static _extractSessionToken(body) {


### PR DESCRIPTION
HTTP cookies will now be valid for any subdomain if root_domain is provided in config.